### PR TITLE
0.18.0

### DIFF
--- a/.cookiecutter.json
+++ b/.cookiecutter.json
@@ -1,0 +1,9 @@
+{
+  "author_name": "Grant Nestor",
+  "author_email": "grantnestor@gmail.com",
+  "mime_type": "application/geo+json",
+  "file_extension": "geojson",
+  "mime_short_name": "GeoJSON",
+  "extension_name": "jupyterlab_geojson"
+}
+    

--- a/.gitignore
+++ b/.gitignore
@@ -1,14 +1,14 @@
 labextension/lib/
 nbextension/lib/
 nbextension/embed/
-*/node_modules/
+node_modules/
 npm-debug.log
 *.egg-info/
+__pycache__/
 build/
 dist/
 
 # Compiled javascript
-jupyterlab_geojson/__pycache__/
 jupyterlab_geojson/static/
 
 # OS X

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # jupyterlab_geojson
 
-A JupyterLab and Jupyter Notebook extension for rendering GeoJSON data
+A JupyterLab and Jupyter Notebook extension for rendering GeoJSON
 
-![output renderer](http://g.recordit.co/i2yLx3WNWy.gif)
+![output renderer](http://g.recordit.co/QAsC7YULcY.gif)
 
 ## Prerequisites
 
-* JupyterLab ^0.17.0 and/or Notebook >=4.3.0
+* JupyterLab ^0.18.0 and/or Notebook >=4.3.0
 
 ## Usage
 
@@ -61,58 +61,28 @@ layer_options={
 
 To render a .geojson file as a tree, simply open it:
 
-![file renderer](http://g.recordit.co/5QvIyPP1kW.gif)
+![file renderer](http://g.recordit.co/cbf0xnQHKn.gif)
 
 ## Install
-
-To install using pip:
 
 ```bash
 pip install jupyterlab_geojson
 # For JupyterLab
-jupyter labextension install --py --sys-prefix jupyterlab_geojson
+jupyter labextension install --symlink --py --sys-prefix jupyterlab_geojson
 jupyter labextension enable --py --sys-prefix jupyterlab_geojson
 # For Notebook
-jupyter nbextension install --py --sys-prefix jupyterlab_geojson
+jupyter nbextension install --symlink --py --sys-prefix jupyterlab_geojson
 jupyter nbextension enable --py --sys-prefix jupyterlab_geojson
 ```
 
 ## Development
 
-### Set up using install script
-
-Use the `install.sh` script to build the Javascript, install the Python package, and install/enable the notebook and lab extensions:
-
-```bash
-bash install.sh --sys-prefix
-```
-
-Use the `build.sh` script to rebuild the Javascript:
-
-```bash
-bash build.sh
-```
-
-### Set up manually
-
-Alternatively, see the `README.md` in `/labextension` and `/nbextension` for extension-specific build instructions. 
-
-To install the Python package:
-
 ```bash
 pip install -e .
-```
-
-To install the extension for JupyterLab:
-
-```bash
+# For JupyterLab
 jupyter labextension install --symlink --py --sys-prefix jupyterlab_geojson
 jupyter labextension enable --py --sys-prefix jupyterlab_geojson
-```
-
-To install the extension for Jupyter Notebook:
-
-```bash
+# For Notebook
 jupyter nbextension install --symlink --py --sys-prefix jupyterlab_geojson
 jupyter nbextension enable --py --sys-prefix jupyterlab_geojson
 ```

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,12 +6,14 @@ This document guides an extension maintainer through creating and publishing a r
 
 Update the version number in `setup.py`, `labextension/package.json`, and `nbextension/package.json`.
 
+Commit your changes, add git tag for this version, and push both commit and tag to your origin/remote repo.
+
 ## Remove generated files
 
 Remove old Javascript bundle and Python package builds:
 
 ```bash
-rm -rf jupyterlab_geojson/static
+git clean -xfd
 ```
 
 ## Build the package

--- a/component/README.md
+++ b/component/README.md
@@ -1,6 +1,6 @@
-# jupyterlab_geojson
+# component
 
-The React component(s)
+A React component for rendering GeoJSON
 
 ## Structure
 

--- a/component/index.js
+++ b/component/index.js
@@ -10,23 +10,15 @@ const LAYER_OPTIONS = {
   maxZoom: 18
 };
 
-export default class Component extends React.Component {
-  constructor(props) {
-    super(props);
-    this.element = null;
-    this.map = null;
-    this.geoJSONLayer = null;
-  }
-
+export default class GeoJSONComponent extends React.Component {
   componentDidMount() {
     const { data, metadata } = this.props;
     this.map = Leaflet.map(this.element);
     this.map.scrollWheelZoom.disable();
     this.tileLayer = Leaflet.tileLayer(
-        (metadata && metadata.tileUrlTemplate) || URL_TEMPLATE,
-        (metadata && metadata.tileLayerOptions) || LAYER_OPTIONS
-      )
-      .addTo(this.map);
+      (metadata && metadata.url_template) || URL_TEMPLATE,
+      (metadata && metadata.layer_options) || LAYER_OPTIONS
+    ).addTo(this.map);
     this.geoJSONLayer = Leaflet.geoJson(data).addTo(this.map);
     this.fitBounds();
   }
@@ -52,5 +44,5 @@ export default class Component extends React.Component {
   fitBounds = () => {
     this.map.fitBounds(this.geoJSONLayer.getBounds());
     this.map.invalidateSize();
-  };
+  }
 }

--- a/jupyterlab_geojson/__init__.py
+++ b/jupyterlab_geojson/__init__.py
@@ -1,9 +1,7 @@
-from IPython.display import DisplayObject, display
-import json
+from IPython.display import display, JSON
 
 # Running `npm run build` will create static resources in the static
 # directory of this Python package (and create that directory if necessary).
-
 
 def _jupyter_labextension_paths():
     return [{
@@ -19,68 +17,24 @@ def _jupyter_nbextension_paths():
         'require': 'jupyterlab_geojson/extension'
     }]
 
-class GeoJSON(DisplayObject):
-    """GeoJSON expects JSON-able dict
-
-    not an already-serialized JSON string.
+# A display class that can be used within a notebook. 
+#   from jupyterlab_geojson import GeoJSON
+#   GeoJSON(data)
+    
+class GeoJSON(JSON):
+    """A display class for displaying GeoJSON visualizations in the Jupyter Notebook and IPython kernel.
+    
+    GeoJSON expects a JSON-able dict, not serialized JSON strings.
 
     Scalar types (None, number, string) are not allowed, only dict containers.
     """
-    # wrap data in a property, which warns about passing already-serialized JSON
-    _data = None
-    
-    def __init__(self, data=None, url_template=None, layer_options=None, url=None, filename=None, metadata=None):
-        """Create a GeoJSON display object given raw data.
-
-        Parameters
-        ----------
-        data : dict or list
-            VegaLite data. Not an already-serialized JSON string.
-            Scalar types (None, number, string) are not allowed, only dict
-            or list containers.
-        url_template : string
-            Leaflet TileLayer URL template: http://leafletjs.com/reference.html#url-template
-        layer_options : dict
-            Leaflet TileLayer options: http://leafletjs.com/reference.html#tilelayer-options
-        url : unicode
-            A URL to download the data from.
-        filename : unicode
-            Path to a local file to load the data from.
-        metadata: dict
-            Specify extra metadata to attach to the json display object.
-        """
-        self.url_template = url_template
-        self.layer_options = layer_options
-        self.metadata = metadata
-        super(GeoJSON, self).__init__(data=data, url=url, filename=filename)
-
-    def _check_data(self):
-        if self.data is not None and not isinstance(self.data, dict):
-            raise TypeError("%s expects a JSONable dict, not %r" % (self.__class__.__name__, self.data))
-        
-    @property
-    def data(self):
-        return self._data
-    
-    @data.setter
-    def data(self, data):
-        if isinstance(data, str):
-            data = json.loads(data)
-        self._data = data
 
     def _ipython_display_(self):
-        md = {}
-        if self.url_template:
-            md['tileUrlTemplate'] = self.url_template
-        if self.layer_options:
-            md['tileLayerOptions'] = self.layer_options
-        if self.metadata:
-            md.update(self.metadata)
         bundle = {
             'application/geo+json': self.data,
             'text/plain': '<jupyterlab_geojson.GeoJSON object>'
         }
         metadata = {
-            'application/geo+json': md
+            'application/geo+json': self.metadata
         }
-        display(bundle, metadata=metadata, raw=True)
+        display(bundle, metadata=metadata, raw=True) 

--- a/labextension/README.md
+++ b/labextension/README.md
@@ -1,10 +1,10 @@
-# jupyterlab_geojson JupyterLab extension
+# labextension
 
 A JupyterLab extension for rendering GeoJSON
 
 ## Prerequisites
 
-* `jupyterlab@^0.17.0`
+* `jupyterlab@^0.18.0`
 
 ## Development
 
@@ -24,4 +24,17 @@ Watch `/src` directory and re-build on changes:
 
 ```bash
 npm run watch
+```
+
+Manage extension
+
+```bash
+# Install
+npm run extension:install
+# Enable
+npm run extension:enable
+# Disable
+npm run extension:disable
+# Uninstall
+npm run extension:uninstall
 ```

--- a/labextension/build_extension.js
+++ b/labextension/build_extension.js
@@ -38,10 +38,14 @@ buildExtension({
           test: /\.js$/,
           include: [
             path.join(__dirname, 'src'),
-            path.join(__dirname, 'node_modules', 'jupyterlab_geojson_react')
+            path.join(
+              __dirname,
+              'node_modules',
+              'jupyterlab_geojson_react'
+            )
           ],
           loader: 'babel-loader',
-          query: { presets: [ 'latest', 'stage-0', 'react' ] }
+          query: { presets: ['latest', 'stage-0', 'react'] }
         }
       ]
     }

--- a/labextension/package.json
+++ b/labextension/package.json
@@ -1,10 +1,10 @@
 {
   "private": true,
   "name": "jupyterlab_geojson_labextension",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "A JupyterLab extension for rendering GeoJSON",
   "author": "Grant Nestor <grantnestor@gmail.com>",
-  "main": "lib/plugin.js",
+  "main": "src/plugin.js",
   "keywords": [
     "jupyter",
     "jupyterlab",
@@ -21,14 +21,18 @@
     "extension:disable": "jupyter labextension disable --py --sys-prefix jupyterlab_geojson"
   },
   "dependencies": {
-    "jupyterlab": "^0.17.0",
-    "@phosphor/algorithm": "^0.1.0",
-    "@phosphor/widgets": "^0.1.3",
+    "@jupyterlab/apputils": "^0.1.3",
+    "@jupyterlab/codemirror": "^0.1.3",
+    "@jupyterlab/docregistry": "^0.1.3",
+    "@jupyterlab/rendermime": "^0.1.3",
+    "@phosphor/algorithm": "^0.1.1",
+    "@phosphor/virtualdom": "^0.1.1",
+    "@phosphor/widgets": "^0.3.0",
     "react": "^15.3.2",
     "react-dom": "^15.3.2"
   },
   "devDependencies": {
-    "@jupyterlab/extension-builder": ">=0.10.0",
+    "@jupyterlab/extension-builder": "^0.10.0",
     "babel-core": "^6.18.2",
     "babel-loader": "^6.2.7",
     "babel-preset-latest": "^6.16.0",

--- a/labextension/src/doc.js
+++ b/labextension/src/doc.js
@@ -1,37 +1,55 @@
 import { Widget } from '@phosphor/widgets';
-import { ABCWidgetFactory } from 'jupyterlab/lib/docregistry';
-import { ActivityMonitor } from 'jupyterlab/lib/common/activitymonitor';
+import { ABCWidgetFactory } from '@jupyterlab/docregistry';
+import { ActivityMonitor } from '@jupyterlab/coreutils';
+import { runMode } from '@jupyterlab/codemirror';
 import React from 'react';
 import ReactDOM from 'react-dom';
-import GeoJSON from 'jupyterlab_geojson_react';
+import GeoJSONComponent from 'jupyterlab_geojson_react';
 
-/**
- * The class name added to a DocWidget.
- */
 const CLASS_NAME = 'jp-DocWidgetGeoJSON';
-
-/**
- * The timeout to wait for change activity to have ceased before rendering.
- */
 const RENDER_TIMEOUT = 1000;
 
 /**
- * A widget for rendering jupyterlab_geojson files.
+ * A component for rendering error messages
+ */
+class ErrorDisplay extends React.Component {
+  componentDidUpdate() {
+    runMode(this.props.content, { name: 'javascript', json: true }, this.ref);
+  }
+  render() {
+    return (
+      <div className="jp-RenderedText jp-mod-error">
+        <h2>{this.props.message}</h2>
+        <pre
+          ref={ref => {
+            this.ref = ref;
+          }}
+          className="CodeMirror cm-s-jupyter CodeMirror-wrap"
+        />
+      </div>
+    );
+  }
+}
+
+/**
+ * A widget for rendering jupyterlab_geojson files
  */
 export class DocWidget extends Widget {
-
   constructor(context) {
     super();
     this._context = context;
-    this._height = this.node.offsetWidth;
-    this._height = this.node.offsetHeight;
+    this._onPathChanged();
     this.addClass(CLASS_NAME);
-    context.model.contentChanged.connect(() => {
+    context.ready.then(() => {
       this.update();
+      /* Re-render when the document content changes */
+      context.model.contentChanged.connect(this.update, this);
+      /* Re-render when the document path changes */
+      context.fileChanged.connect(this.update, this);
     });
-    context.pathChanged.connect(() => {
-      this.update();
-    });
+    /* Update title when path changes */
+    context.pathChanged.connect(this._onPathChanged, this);
+    /* Throttle re-renders until changes have stopped */
     this._monitor = new ActivityMonitor({
       signal: context.model.contentChanged,
       timeout: RENDER_TIMEOUT
@@ -40,98 +58,84 @@ export class DocWidget extends Widget {
   }
 
   /**
-   * Dispose of the resources used by the widget.
+   * The widget's context
+   */
+  get context() {
+    return this._context;
+  }
+
+  /**
+   * Dispose of the resources used by the widget
    */
   dispose() {
     if (!this.isDisposed) {
       this._context = null;
-      ReactDOM.unmountComponentAtNode(this.node);
       this._monitor.dispose();
       super.dispose();
     }
   }
 
   /**
-   * A message handler invoked on an `'update-request'` message.
+   * A message handler invoked on an `'after-attach'` message
    */
-  onUpdateRequest(msg) {
-    this.title.label = this._context.path.split('/').pop();
-    if (this.isAttached) {
-      const content = this._context.model.toString();
-      try {
-        const data = JSON.parse(content);
-        ReactDOM.render(
-          <GeoJSON data={data} width={this._width} height={this._height} />,
-          this.node
-        );
-      } catch (error) {
-        
-        const ErrorDisplay = props => (
-          <div
-            className="jp-RenderedText jp-mod-error"
-            style={{
-              width: '100%',
-              minHeight: '100%',
-              textAlign: 'center',
-              padding: 10,
-              boxSizing: 'border-box'
-            }}
-          >
-            <span
-              style={{
-                fontSize: 18,
-                fontWeight: 500
-              }}
-            >{props.message}</span>
-            <pre
-              style={{
-                textAlign: 'left',
-                padding: 10,
-                overflow: 'hidden'
-              }}
-            >{props.content}</pre>
-          </div>
-        );
-        
-        ReactDOM.render(
-          <ErrorDisplay
-            message="Invalid JSON"
-            content={content}
-          />,
-          this.node
-        );
-      }
-    }
+  onAfterAttach(msg) {
+    /* Render initial data */
+    this.update();
   }
 
   /**
-   * A message handler invoked on an `'after-attach'` message.
+   * A message handler invoked on an `'before-detach'` message
    */
-  onAfterAttach(msg) {
+  onBeforeDetach(msg) {
+    /* Dispose of resources used by  widget */
+    ReactDOM.unmountComponentAtNode(this.node);
+  }
+
+  /**
+   * A message handler invoked on a `'resize'` message
+   */
+  onResize(msg) {
+    /* Re-render on resize */
     this.update();
   }
 
-  onResize(msg) {
-    this._width = msg.width;
-    this._height = msg.height;
-    this.update();
+  /**
+   * A message handler invoked on an `'update-request'` message
+   */
+  onUpdateRequest(msg) {
+    if (this.isAttached && this._context.isReady) this._render();
+  }
+
+  _render() {
+    const content = this._context.model.toString();
+    try {
+      const props = {
+        data: JSON.parse(content),
+        width: this.node.offsetWidth,
+        height: this.node.offsetHeight
+      };
+      ReactDOM.render(<GeoJSONComponent {...props} />, this.node);
+    } catch (error) {
+      ReactDOM.render(
+        <ErrorDisplay message="Invalid JSON" content={content} />,
+        this.node
+      );
+    }
+  }
+
+  _onPathChanged() {
+    this.title.label = this._context.path.split('/').pop();
   }
 }
 
 /**
- * A widget factory for DocWidget.
+ * A widget factory for DocWidget
  */
 export class DocWidgetFactory extends ABCWidgetFactory {
-  constructor(options) {
-    super(options);
-  }
-
   /**
-   * Create a new widget given a context.
+   * Create a new widget instance
    */
-  createNewWidget(context, kernel) {
-    const widget = new DocWidget(context);
-    this.widgetCreated.emit(widget);
-    return widget;
+  createNewWidget(context) {
+    return new DocWidget(context);
   }
 }

--- a/labextension/src/index.css
+++ b/labextension/src/index.css
@@ -1,17 +1,33 @@
-/* 
-  Copyright (c) Jupyter Development Team.
-  Distributed under the terms of the Modified BSD License. 
-*/
-
 .jp-OutputWidgetGeoJSON, .jp-DocWidgetGeoJSON {
   width: 100%;
   padding: 0;
 }
 
 .jp-OutputWidgetGeoJSON {
+  padding-top: 5px;
   height: 360px;
 }
 
 .jp-DocWidgetGeoJSON {
+  overflow: hidden;
+}
+
+.jp-DocWidgetGeoJSON .jp-mod-error {
+  width: 100%;
+  min-height: 100%;
+  text-align: center; 
+  padding: 10px; 
+  box-sizing: border-box;
+}
+
+.jp-DocWidgetGeoJSON .jp-mod-error h2 {
+  font-size: 18px; 
+  font-weight: 500; 
+  padding-bottom: 10px;
+}
+
+.jp-DocWidgetGeoJSON .jp-mod-error pre {
+  text-align: left; 
+  padding: 10px; 
   overflow: hidden;
 }

--- a/labextension/src/output.js
+++ b/labextension/src/output.js
@@ -1,64 +1,89 @@
 import { Widget } from '@phosphor/widgets';
 import React from 'react';
 import ReactDOM from 'react-dom';
-import GeoJSON from 'jupyterlab_geojson_react';
+import GeoJSONComponent from 'jupyterlab_geojson_react';
 
-/**
- * The class name added to this OutputWidget.
- */
+const MIME_TYPE = 'application/geo+json';
 const CLASS_NAME = 'jp-OutputWidgetGeoJSON';
 
 /**
- * A widget for rendering GeoJSON.
+ * A Phosphor widget for rendering GeoJSON
  */
 export class OutputWidget extends Widget {
   constructor(options) {
     super();
+    this._mimeType = options.mimeType;
+    this._data = options.model.data;
+    this._metadata = options.model.metadata;
     this.addClass(CLASS_NAME);
-    this._data = options.model.data.get(options.mimeType);
-    this._metadata = options.model.metadata.get(options.mimeType);
   }
 
   /**
-   * A message handler invoked on an `'after-attach'` message.
+   * A message handler invoked on an `'after-attach'` message
    */
   onAfterAttach(msg) {
+    /* Render initial data */
     this._render();
   }
 
   /**
-   * A message handler invoked on an `'before-detach'` message.
+   * A message handler invoked on an `'before-detach'` message
    */
   onBeforeDetach(msg) {
+    /* Dispose of resources used by this widget */
     ReactDOM.unmountComponentAtNode(this.node);
   }
 
   /**
-   * A render function given the widget's DOM node.
+   * A message handler invoked on a `'child-added'` message
+   */
+  onChildAdded(msg) {
+    /* e.g. Inject a static image representation into the mime bundle for
+     *  endering on Github, etc. 
+     */
+    // renderLibrary.toPng(this.node).then(url => {
+    //   const data = url.split(',')[1];
+    //   this._data.set('image/png', data);
+    // })
+  }
+
+  /**
+   * A message handler invoked on a `'resize'` message
+   */
+  onResize(msg) {
+    /* Re-render on resize */
+    this._render();
+  }
+
+  /**
+   * Render data to DOM node
    */
   _render() {
-    ReactDOM.render(
-      <GeoJSON data={this._data} metadata={this._metadata} />,
-      this.node
-    );
+    const props = {
+      data: this._data.get(this._mimeType),
+      metadata: this._metadata.get(this._mimeType),
+      width: this.node.offsetWidth,
+      height: this.node.offsetHeight
+    };
+    ReactDOM.render(<GeoJSONComponent {...props} />, this.node);
   }
 }
 
 export class OutputRenderer {
   /**
-   * The mime types this OutputRenderer accepts.
+   * The mime types that this OutputRenderer accepts
    */
-  mimeTypes = ['application/geo+json'];
+  mimeTypes = [MIME_TYPE];
 
   /**
-   * Whether the renderer can render given the render options.
+   * Whether the renderer can render given the render options
    */
   canRender(options) {
     return this.mimeTypes.indexOf(options.mimeType) !== -1;
   }
 
   /**
-   * Render the transformed mime bundle.
+   * Render the transformed mime bundle
    */
   render(options) {
     return new OutputWidget(options);

--- a/nbextension/README.md
+++ b/nbextension/README.md
@@ -1,4 +1,4 @@
-# jupyterlab_geojson Jupyter Notebook extension
+# nbextension
 
 A Jupyter Notebook extension for rendering GeoJSON
 
@@ -24,4 +24,17 @@ Watch `/src` directory and re-build on changes:
 
 ```bash
 npm run watch
+```
+
+Manage extension
+
+```bash
+# Install
+npm run extension:install
+# Enable
+npm run extension:enable
+# Disable
+npm run extension:disable
+# Uninstall
+npm run extension:uninstall
 ```

--- a/nbextension/package.json
+++ b/nbextension/package.json
@@ -1,9 +1,10 @@
 {
+  "private": true,
   "name": "jupyterlab_geojson_nbextension",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "A Jupyter Notebook extension for rendering GeoJSON",
   "author": "Grant Nestor <grantnestor@gmail.com>",
-  "main": "lib/index.js",
+  "main": "src/index.js",
   "keywords": [
     "jupyter",
     "jupyterlab",
@@ -14,28 +15,27 @@
     "watch": "watch \"npm install\" src ../component --wait 10 --ignoreDotFiles",
     "preinstall": "npm install ../component",
     "prepublish": "npm run build",
-    "extension:install": "jupyter nbextension install --symlink --py --sys-prefix notebook_json",
-    "extension:uninstall": "jupyter nbextension uninstall --py --sys-prefix notebook_json",
-    "extension:enable": "jupyter nbextension enable --py --sys-prefix notebook_json",
-    "extension:disable": "jupyter nbextension disable --py --sys-prefix notebook_json"
+    "extension:install": "jupyter nbextension install --symlink --py --sys-prefix jupyterlab_geojson",
+    "extension:uninstall": "jupyter nbextension uninstall --py --sys-prefix jupyterlab_geojson",
+    "extension:enable": "jupyter nbextension enable --py --sys-prefix jupyterlab_geojson",
+    "extension:disable": "jupyter nbextension disable --py --sys-prefix jupyterlab_geojson"
   },
   "dependencies": {
     "react": "^15.3.2",
-    "react-dom": "^15.3.2",
-    "underscore": "^1.8.3"
+    "react-dom": "^15.3.2"
   },
   "devDependencies": {
     "babel-core": "^6.18.2",
-    "babel-loader": "^6.2.7",
+    "babel-loader": "^6.4.0",
     "babel-preset-latest": "^6.16.0",
     "babel-preset-react": "^6.16.0",
-    "babel-preset-stage-0": "^6.16.0",
+    "babel-preset-stage-0": "^6.22.0",
     "css-loader": "^0.25.0",
     "file-loader": "^0.9.0",
     "json-loader": "^0.5.4",
     "style-loader": "^0.13.1",
     "url-loader": "^0.5.7",
     "watch": "^1.0.1",
-    "webpack": "^1.12.14"
+    "webpack": "^2.2.0"
   }
 }

--- a/nbextension/src/extension.js
+++ b/nbextension/src/extension.js
@@ -24,11 +24,14 @@ export function load_ipython_extension() {
   define(
     [
       'nbextensions/jupyterlab_geojson/index',
-      'base/js/namespace'
+      'base/js/namespace',
+      'base/js/events',
+      'notebook/js/outputarea'
     ],
-    (Extension, Jupyter) => {
+    (Extension, Jupyter, events, outputarea) => {
       const { notebook } = Jupyter;
-      Extension.register_renderer(notebook);
+      const { OutputArea } = outputarea;
+      Extension.register_renderer(notebook, events, OutputArea);
       Extension.render_cells(notebook);
     }
   );

--- a/nbextension/src/index.css
+++ b/nbextension/src/index.css
@@ -1,8 +1,8 @@
 .output_subarea.output_GeoJSON {
   padding: 0;
-  width: 100%;
+  padding-top: 0.4em;
+  max-width: 100%;
   height: 360px;
-  overflow: hidden;
 }
 .leaflet-control a {
   text-decoration: none !important;

--- a/nbextension/src/renderer.js
+++ b/nbextension/src/renderer.js
@@ -5,48 +5,94 @@ import './index.css';
 
 const MIME_TYPE = 'application/geo+json';
 const CLASS_NAME = 'output_GeoJSON rendered_html';
+const DEFAULT_WIDTH = 840;
+const DEFAULT_HEIGHT = 360;
 
 /**
- * Render data to the output area
+ * Render data to the DOM node
  */
-function render(data, node) {
-    const ref = ReactDOM.render(<GeoJSONComponent data={data} />, node);
-    // Hack: Leaflet maps don't display all tiles unless the window is
-    // resized or `map.invalidateSize()` is called.
-    // https://github.com/Leaflet/Leaflet/issues/694
-    setTimeout(() => ref.map.invalidateSize(), 1000);
+function render(props, node) {
+  return ReactDOM.render(<GeoJSONComponent {...props} />, node);
 }
 
 /**
- * Register the mime type and append_mime_type function with the notebook's 
- * output_area
+ * Handle when an output is cleared or removed
  */
-export function register_renderer(notebook) {
-  // Get an instance of output_area from the notebook object
-  const { output_area } = notebook
-    .get_cells()
-    .reduce((result, cell) => cell.output_area ? cell : result, {});
-  // A function to render output of 'application/geo+json' mime type
-  const append_mime = function(json, md, element) {
-    const type = MIME_TYPE;
-    const toinsert = this.create_output_subarea(md, CLASS_NAME, type);
+function handleClearOutput(event, { cell: { output_area } }) {
+  /* Get rendered DOM node */
+  const toinsert = output_area.element.find(`.${CLASS_NAME.split(' ')[0]}`);
+  /* e.g. Dispose of resources used by renderer library */
+  if (toinsert[0]) ReactDOM.unmountComponentAtNode(toinsert[0]);
+}
+
+/**
+ * Handle when a new output is added
+ */
+function handleAddOutput(event, { output, output_area }) {
+  /* Get rendered DOM node */
+  const toinsert = output_area.element.find(`.${CLASS_NAME.split(' ')[0]}`);
+  /** Hack: Leaflet maps don't display all tiles unless the window is
+    * resized or `map.invalidateSize()` is called.
+    * https://github.com/Leaflet/Leaflet/issues/694
+   */
+  if (toinsert[0]) output_area.ref.map.invalidateSize();
+}
+
+/**
+ * Register the mime type and append_mime function with the notebook's 
+ * output area
+ */
+export function register_renderer(notebook, events, OutputArea) {
+  /* A function to render output of 'application/geo+json' mime type */
+  const append_mime = function(data, metadata, element) {
+    /* Create a DOM node to render to */
+    const toinsert = this.create_output_subarea(
+      metadata,
+      CLASS_NAME,
+      MIME_TYPE
+    );
     this.keyboard_manager.register_events(toinsert);
-    render(json, toinsert[(0)]);
+    /* Render data to DOM node */
+    const props = {
+      data,
+      metadata: metadata[MIME_TYPE],
+      width: element.width(),
+      height: DEFAULT_HEIGHT
+    };
+    this.ref = render(props, toinsert[0]);
     element.append(toinsert);
+    const output_area = this;
+    this.element.on('changed', () => {
+      if (output_area.outputs.length > 0) ReactDOM.unmountComponentAtNode(toinsert[0]);
+    });
     return toinsert;
   };
-  // // Calculate the index of this renderer in `output_area.display_order`
-  // // e.g. Insert this renderer after any renderers with mime type that matches "+json"
+
+  /* Handle when an output is cleared or removed */
+  events.on('clear_output.CodeCell', handleClearOutput);
+  events.on('delete.Cell', handleClearOutput);
+
+  /* Handle when a new output is added */
+  events.on('output_added.OutputArea', handleAddOutput);
+
+  /**
+   * Calculate the index of this renderer in `output_area.display_order`
+   * e.g. Insert this renderer after any renderers with mime type that matches 
+   * "+json"
+   */
   // const mime_types = output_area.mime_types();
   // const json_types = mime_types.filter(mimetype => mimetype.includes('+json'));
   // const index = mime_types.lastIndexOf(json_types.pop() + 1);
-  // // ...or just insert it at the top
+  /* ...or just insert it at the top */
   const index = 0;
-  // Register the mime type and append_mime_type function with the output_area
-  output_area.register_mime_type(MIME_TYPE, append_mime, {
-    // Is output safe (no Javascript)?
+
+  /**
+   * Register the mime type and append_mime function with output_area
+   */
+  OutputArea.prototype.register_mime_type(MIME_TYPE, append_mime, {
+    /* Is output safe? */
     safe: true,
-    // Index of renderer in `output_area.display_order`
+    /* Index of renderer in `output_area.display_order` */
     index: index
   });
 }
@@ -56,16 +102,16 @@ export function register_renderer(notebook) {
  * on load notebook
  */
 export function render_cells(notebook) {
-  // Get all cells in notebook
+  /* Get all cells in notebook */
   notebook.get_cells().forEach(cell => {
-    // If a cell has output data of 'application/geo+json' mime type
+    /* If a cell has output data of 'application/geo+json' mime type */
     if (
-      cell.output_area && 
-      cell.output_area.outputs.find(output => 
-        output.data && output.data[MIME_TYPE]
+      cell.output_area &&
+      cell.output_area.outputs.find(
+        output => output.data && output.data[MIME_TYPE]
       )
     ) {
-      // Re-render the cell by executing it
+      /* Re-render the cell */
       notebook.render_cell_output(cell);
     }
   });

--- a/nbextension/webpack.config.js
+++ b/nbextension/webpack.config.js
@@ -1,5 +1,5 @@
-var version = require('./package.json').version;
 var path = require('path');
+var version = require('./package.json').version;
 
 /**
  * Custom webpack loaders are generally the same for all webpack bundles, hence
@@ -38,6 +38,21 @@ var loaders = [
   }
 ];
 
+var base = {
+  output: {
+    libraryTarget: 'amd',
+    devtoolModuleFilenameTemplate: 'webpack:///[absolute-resource-path]'
+  },
+  devtool: 'source-map',
+  module: { loaders },
+  externals: [
+    'nbextensions/jupyterlab_geojson/index',
+    'base/js/namespace',
+    'base/js/events',
+    'notebook/js/outputarea'
+  ]
+};
+
 module.exports = [
   /**
    * Notebook extension
@@ -48,25 +63,18 @@ module.exports = [
    * "load_ipython_extension" function which is required for any notebook
    * extension.
    */
-  {
+  Object.assign({}, base, {
     entry: path.join(__dirname, 'src', 'extension.js'),
-    output: {
+    output: Object.assign({}, base.output, {
       filename: 'extension.js',
       path: path.join(
         __dirname,
         '..',
         'jupyterlab_geojson',
         'static'
-      ),
-      libraryTarget: 'amd'
-    },
-    devtool: 'source-map',
-    module: { loaders },
-    externals: [
-      'nbextensions/jupyterlab_geojson/index', 
-      'base/js/namespace'
-    ]
-  },
+      )
+    })
+  }),
   /**
    * Bundle for the notebook containing the custom widget views and models
    * 
@@ -75,21 +83,18 @@ module.exports = [
    * 
    * It must be an amd module
    */
-  {
+  Object.assign({}, base, {
     entry: path.join(__dirname, 'src', 'index.js'),
-    output: {
+    output: Object.assign({}, base.output, {
       filename: 'index.js',
       path: path.join(
         __dirname,
         '..',
         'jupyterlab_geojson',
         'static'
-      ),
-      libraryTarget: 'amd'
-    },
-    devtool: 'source-map',
-    module: { loaders }
-  },
+      )
+    })
+  }),
   /**
    * Embeddable jupyterlab_geojson bundle
    * 
@@ -105,17 +110,14 @@ module.exports = [
    * The target bundle is always `lib/index.js`, which is the path required
    * by the custom widget embedder.
    */
-  {
+  Object.assign({}, base, {
     entry: './src/embed.js',
-    output: {
+    output: Object.assign({}, base.output, {
       filename: 'index.js',
       path: path.join(__dirname, 'embed'),
-      libraryTarget: 'amd',
-      publicPath: (
-        'https://unpkg.com/jupyterlab_geojson@' + version + '/lib/'
-      )
-    },
-    devtool: 'source-map',
-    module: { loaders }
-  }
+      publicPath: 'https://unpkg.com/jupyterlab_geojson@' +
+        version +
+        '/lib/'
+    })
+  })
 ];

--- a/setup.py
+++ b/setup.py
@@ -1,35 +1,43 @@
-import os
-import sys
-from distutils.core import setup
+from setuptools import setup
+from setupbase import create_cmdclass, install_npm
 
-
-class NodeModulesMissing(Exception):
-    "raised when node_modules directory is not found"
-    pass
-
-
-if 'develop' in sys.argv or any(a.startswith('bdist') for a in sys.argv):
-    import setuptools
-
-# Ensure that js has been built. This does not guaruntee that the packages
-# are update to date. In the future we might do a more expensive check
-# involving file hashes, but only on sdist and bdist builds.
-if not os.path.exists('labextension/node_modules') and not os.path.exists('nbextension/node_modules'):
-    raise NodeModulesMissing("Before Python package can be installed or built, "
-                             "JavaScript components must be built using npm. "
-                             "Run the following and then retry: "
-                             "\nnpm install")
+cmdclass = create_cmdclass(['labextension', 'nbextension'])
+cmdclass['labextension'] = install_npm('labextension')
+cmdclass['nbextension'] = install_npm('nbextension')
 
 setup_args = dict(
     name                 = 'jupyterlab_geojson',
-    version              = '0.17.0',
+    version              = '0.18.0',
     packages             = ['jupyterlab_geojson'],
     author               = 'Grant Nestor',
     author_email         = 'grantnestor@gmail.com',
-    keywords             = ['jupyter', 'jupyterlab', 'labextension', 'notebook', 'nbextension'],
-    include_package_data = True,
-    install_requires = [
-        'jupyterlab>=0.17.0',
+    url                  = 'http://jupyter.org',
+    license              = 'BSD',
+    platforms            = "Linux, Mac OS X, Windows",
+    keywords             = [
+        'ipython', 
+        'jupyter', 
+        'jupyterlab', 
+        'extension', 
+        'renderer',
+        'geojson'
+    ],
+    classifiers          = [
+        'Intended Audience :: Developers',
+        'Intended Audience :: System Administrators',
+        'Intended Audience :: Science/Research',
+        'License :: OSI Approved :: BSD License',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+    ],
+    cmdclass             = cmdclass,
+    install_requires     = [
+        'jupyterlab>=0.18.0',
+        'notebook>=4.3.0',
         'ipython>=1.0.0'
     ]
 )

--- a/setupbase.py
+++ b/setupbase.py
@@ -1,0 +1,312 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+import os
+from os.path import join as pjoin
+import functools
+import pipes
+
+from setuptools import Command
+from setuptools.command.build_py import build_py
+from setuptools.command.sdist import sdist
+from setuptools.command.develop import develop
+from setuptools.command.bdist_egg import bdist_egg
+from distutils import log
+from subprocess import check_call
+import sys
+
+try:
+    from wheel.bdist_wheel import bdist_wheel
+except ImportError:
+    bdist_wheel = None
+
+if sys.platform == 'win32':
+    from subprocess import list2cmdline
+else:
+    def list2cmdline(cmd_list):
+        return ' '.join(map(pipes.quote, cmd_list))
+
+
+__version__ = '0.1.0'
+
+# ---------------------------------------------------------------------------
+# Top Level Variables
+# ---------------------------------------------------------------------------
+
+
+here = os.path.abspath(os.path.dirname(sys.argv[0]))
+is_repo = os.path.exists(pjoin(here, '.git'))
+node_modules = pjoin(here, 'node_modules')
+npm_path = ':'.join([
+    pjoin(here, 'node_modules', '.bin'),
+    os.environ.get('PATH', os.defpath),
+])
+
+if "--skip-npm" in sys.argv:
+    print("Skipping npm install as requested.")
+    skip_npm = True
+    sys.argv.remove("--skip-npm")
+else:
+    skip_npm = False
+
+# ---------------------------------------------------------------------------
+# Public Functions
+# ---------------------------------------------------------------------------
+
+
+def get_data_files(top):
+    """Get data files"""
+
+    data_files = []
+    ntrim = len(here + os.path.sep)
+
+    for (d, dirs, filenames) in os.walk(top):
+        data_files.append((
+            d[ntrim:],
+            [pjoin(d, f) for f in filenames]
+        ))
+    return data_files
+
+
+def find_packages(top):
+    """
+    Find all of the packages.
+    """
+    packages = []
+    for d, _, _ in os.walk(top):
+        if os.path.exists(pjoin(d, '__init__.py')):
+            packages.append(d.replace(os.path.sep, '.'))
+
+
+def create_cmdclass(wrappers=None, data_dirs=None):
+    """Create a command class with the given optional wrappers.
+    Parameters
+    ----------
+    wrappers: list(str), optional
+        The cmdclass names to run before running other commands
+    data_dirs: list(str), optional.
+        The directories containing static data.
+    """
+    egg = bdist_egg if 'bdist_egg' in sys.argv else bdist_egg_disabled
+    wrappers = wrappers or []
+    data_dirs = data_dirs or []
+    wrapper = functools.partial(wrap_command, wrappers, data_dirs)
+    cmdclass = dict(
+        build_py=wrapper(build_py, strict=is_repo),
+        sdist=wrapper(sdist, strict=True),
+        bdist_egg=egg,
+        develop=wrapper(develop, strict=True)
+    )
+    if bdist_wheel:
+        cmdclass['bdist_wheel'] = wrapper(bdist_wheel, strict=True)
+    return cmdclass
+
+
+def run(cmd, *args, **kwargs):
+    """Echo a command before running it.  Defaults to repo as cwd"""
+    log.info('> ' + list2cmdline(cmd))
+    kwargs.setdefault('cwd', here)
+    kwargs.setdefault('shell', sys.platform == 'win32')
+    if not isinstance(cmd, list):
+        cmd = cmd.split()
+    return check_call(cmd, *args, **kwargs)
+
+
+def is_stale(target, source):
+    """Test whether the target file/directory is stale based on the source
+       file/directory.
+    """
+    if not os.path.exists(target):
+        return True
+    return mtime(target) < mtime(source)
+
+
+class BaseCommand(Command):
+    """Empty command because Command needs subclasses to override too much"""
+    user_options = []
+
+    def initialize_options(self):
+        pass
+
+    def finalize_options(self):
+        pass
+
+    def get_inputs(self):
+        return []
+
+    def get_outputs(self):
+        return []
+
+
+def combine_commands(*commands):
+    """Return a Command that combines several commands."""
+
+    class CombinedCommand(Command):
+
+        def initialize_options(self):
+            self.commands = []
+            for C in commands:
+                self.commands.append(C(self.distribution))
+            for c in self.commands:
+                c.initialize_options()
+
+        def finalize_options(self):
+            for c in self.commands:
+                c.finalize_options()
+
+        def run(self):
+            for c in self.commands:
+                c.run()
+    return CombinedCommand
+
+
+def mtime(path):
+    """shorthand for mtime"""
+    return os.stat(path).st_mtime
+
+
+def install_npm(path=None, build_dir=None, source_dir=None, build_cmd='build'):
+    """Return a Command for managing an npm installation.
+    Parameters
+    ----------
+    path: str, optional
+        The base path of the node package.  Defaults to the repo root.
+    build_dir: str, optional
+        The target build directory.  If this and source_dir are given,
+        the JavaScript will only be build if necessary.
+    source_dir: str, optional
+        The source code directory.
+    build_cmd: str, optional
+        The npm command to build assets to the build_dir.
+    """
+
+    class NPM(BaseCommand):
+        description = 'install package.json dependencies using npm'
+
+        def run(self):
+            if skip_npm:
+                log.info('Skipping npm-installation')
+                return
+            node_package = path or here
+            node_modules = pjoin(node_package, 'node_modules')
+
+            if not which("npm"):
+                log.error("`npm` unavailable.  If you're running this command "
+                          "using sudo, make sure `npm` is availble to sudo")
+                return
+            if is_stale(node_modules, pjoin(node_package, 'package.json')):
+                log.info('Installing build dependencies with npm.  This may '
+                         'take a while...')
+                run(['npm', 'install'], cwd=node_package)
+            if build_dir and source_dir:
+                should_build = is_stale(build_dir, source_dir)
+            else:
+                should_build = True
+            if should_build:
+                run(['npm', 'run', build_cmd], cwd=node_package)
+
+    return NPM
+
+
+# `shutils.which` function copied verbatim from the Python-3.3 source.
+def which(cmd, mode=os.F_OK | os.X_OK, path=None):
+    """Given a command, mode, and a PATH string, return the path which
+    conforms to the given mode on the PATH, or None if there is no such
+    file.
+    `mode` defaults to os.F_OK | os.X_OK. `path` defaults to the result
+    of os.environ.get("PATH"), or can be overridden with a custom search
+    path.
+    """
+
+    # Check that a given file can be accessed with the correct mode.
+    # Additionally check that `file` is not a directory, as on Windows
+    # directories pass the os.access check.
+    def _access_check(fn, mode):
+        return (os.path.exists(fn) and os.access(fn, mode) and
+                not os.path.isdir(fn))
+
+    # Short circuit. If we're given a full path which matches the mode
+    # and it exists, we're done here.
+    if _access_check(cmd, mode):
+        return cmd
+
+    path = (path or os.environ.get("PATH", os.defpath)).split(os.pathsep)
+
+    if sys.platform == "win32":
+        # The current directory takes precedence on Windows.
+        if os.curdir not in path:
+            path.insert(0, os.curdir)
+
+        # PATHEXT is necessary to check on Windows.
+        pathext = os.environ.get("PATHEXT", "").split(os.pathsep)
+        # See if the given file matches any of the expected path extensions.
+        # This will allow us to short circuit when given "python.exe".
+        matches = [cmd for ext in pathext if cmd.lower().endswith(ext.lower())]
+        # If it does match, only test that one, otherwise we have to try
+        # others.
+        files = [cmd] if matches else [cmd + ext.lower() for ext in pathext]
+    else:
+        # On other platforms you don't have things like PATHEXT to tell you
+        # what file suffixes are executable, so just pass on cmd as-is.
+        files = [cmd]
+
+    seen = set()
+    for dir in path:
+        dir = os.path.normcase(dir)
+        if dir not in seen:
+            seen.add(dir)
+            for thefile in files:
+                name = os.path.join(dir, thefile)
+                if _access_check(name, mode):
+                    return name
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Private Functions
+# ---------------------------------------------------------------------------
+
+
+def wrap_command(cmds, data_dirs, cls, strict=True):
+    """Wrap a setup command
+    Parameters
+    ----------
+    cmds: list(str)
+        The names of the other commands to run prior to the command.
+    strict: boolean, optional
+        Wether to raise errors when a pre-command fails.
+    """
+    class WrappedCommand(cls):
+
+        def run(self):
+            if not getattr(self, 'uninstall', None):
+                try:
+                    [self.run_command(cmd) for cmd in cmds]
+                except Exception:
+                    if strict:
+                        raise
+                    else:
+                        pass
+
+            result = cls.run(self)
+            data_files = []
+            for dname in data_dirs:
+                data_files.extend(get_data_files(dname))
+            # update data-files in case this created new files
+            self.distribution.data_files = data_files
+            return result
+    return WrappedCommand
+
+
+class bdist_egg_disabled(bdist_egg):
+    """Disabled version of bdist_egg
+    Prevents setup.py install performing setuptools' default easy_install,
+    which it should never ever do.
+    """
+
+    def run(self):
+        sys.exit("Aborting implicit building of eggs. Use `pip install .` " +
+                 " to install from source.")


### PR DESCRIPTION
* Add state restoration to labextension
* Add `output_area` event handlers to nbextension that are consistent with those of phosphor’s widget
* Use RequireJS to get OutputArea vs. jQuery
* Remove bash scripts and use setup tools to build Javascript (using jupyter-packaging)